### PR TITLE
build: reduce package size by 75%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,17 @@ src/
 *.tsx
 !dist/**/*.d.ts
 
+# Source maps (large, not needed in npm package)
+**/*.map
+
+# TypeScript build info
+**/*.tsbuildinfo
+
+# Duplicate type declarations (rollup typescript plugin issue)
+dist/core/core/
+dist/core/components/
+dist/core/constants/
+
 # Development files
 .next/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ozdemircibaris/react-image-editor",
   "private": false,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Headless React image editor with blur, crop, shapes, drawing, and undo/redo. Use the hooks for custom UI or the styled components for quick integration.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -24,7 +24,12 @@
     }
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/core/core",
+    "!dist/core/components",
+    "!dist/core/constants",
     "README.md"
   ],
   "sideEffects": false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,12 +33,12 @@ module.exports = [
       {
         file: "dist/index.js",
         format: "cjs",
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: "dist/index.esm.js",
         format: "esm",
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -61,12 +61,12 @@ module.exports = [
       {
         file: "dist/core/index.js",
         format: "cjs",
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: "dist/core/index.esm.js",
         format: "esm",
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [


### PR DESCRIPTION
## Summary

- Disable source maps in rollup config (was ~822KB)
- Exclude tsbuildinfo files from package
- Exclude duplicate type declarations (dist/core/core/, etc.)
- Use specific file patterns in package.json files field

## Results

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Package size | 314.5 KB | 79.5 KB | 75% |
| Unpacked size | 1.2 MB | 286 KB | 76% |
| Files | 87 | 43 | 51% |

Version bump: 1.2.0 → 1.2.1