### PR TITLE
feat: add text tool for adding and styling text on images

### DIFF
--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -8,6 +8,7 @@ export { useBlur } from "./useBlur";
 export { useCrop } from "./useCrop";
 export { useDrawing } from "./useDrawing";
 export { useShapes } from "./useShapes";
+export { useText } from "./useText";
 export { useSelection } from "./useSelection";
 export { useZoom } from "./useZoom";
 export { useExport } from "./useExport";

--- a/src/core/hooks/useHistory.ts
+++ b/src/core/hooks/useHistory.ts
@@ -44,6 +44,7 @@ const DEFAULT_CUSTOM_PROPERTIES = [
   "isDrawing",
   "isShape",
   "shapeType",
+  "isText",
   "selectable",
   "evented",
   "hasControls",

--- a/src/core/hooks/useImageEditor.ts
+++ b/src/core/hooks/useImageEditor.ts
@@ -17,6 +17,7 @@ import { useBlur } from "./useBlur";
 import { useCrop } from "./useCrop";
 import { useDrawing } from "./useDrawing";
 import { useShapes } from "./useShapes";
+import { useText } from "./useText";
 import { useSelection } from "./useSelection";
 import { useZoom } from "./useZoom";
 import { useExport } from "./useExport";
@@ -194,6 +195,12 @@ export function useImageEditor(
     defaultColor: currentColor,
     defaultStrokeWidth: currentStrokeWidth,
     onShapeAdd: () => historyRef.current.saveState(),
+  });
+
+  const text = useText(canvasInstanceRef, originalImageRef, {
+    defaultColor: currentColor,
+    onTextAdd: () => historyRef.current.saveState(),
+    onTextEditEnd: () => historyRef.current.saveState(),
   });
 
   const zoomHook = useZoom(canvasInstanceRef);
@@ -609,6 +616,15 @@ export function useImageEditor(
       addRectangle: shapes.addRectangle,
       addCircle: shapes.addCircle,
       add: shapes.addShape,
+    },
+    text: {
+      add: text.addText,
+      setFontSize: text.setFontSize,
+      setFontFamily: text.setFontFamily,
+      setColor: text.setTextColor,
+      setFontWeight: text.setFontWeight,
+      setFontStyle: text.setFontStyle,
+      fontFamilies: text.fontFamilies,
     },
     selection: {
       enable: selectionHook.enableSelectMode,

--- a/src/core/hooks/useSelection.ts
+++ b/src/core/hooks/useSelection.ts
@@ -194,7 +194,23 @@ export function useSelection(
       const canvas = canvasRef.current;
       if (!canvas || !selectedObject) return;
 
-      selectedObject.set({ stroke: color });
+      const customObj = selectedObject as EditorFabricObject;
+
+      // Text objects use fill for color, shapes use stroke
+      if (customObj.isText || selectedObject.type === "i-text") {
+        selectedObject.set({
+          fill: color,
+          cornerColor: color,
+          borderColor: color,
+        });
+      } else {
+        selectedObject.set({
+          stroke: color,
+          cornerColor: color,
+          borderColor: color,
+        });
+      }
+
       canvas.renderAll();
     },
     [canvasRef, selectedObject]

--- a/src/core/hooks/useText.ts
+++ b/src/core/hooks/useText.ts
@@ -1,0 +1,280 @@
+import { fabric } from "fabric";
+import { useCallback } from "react";
+
+import type { EditorFabricObject, UseTextReturn } from "../types";
+import { getViewportCenter, getImageBounds } from "../utils";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface UseTextOptions {
+  /** Default text color */
+  defaultColor?: string;
+  /** Default font size */
+  defaultFontSize?: number;
+  /** Default font family */
+  defaultFontFamily?: string;
+  /** Callback when text is added */
+  onTextAdd?: (text: fabric.IText) => void;
+  /** Callback when text editing ends */
+  onTextEditEnd?: (text: fabric.IText) => void;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_FONT_FAMILIES = [
+  "Arial",
+  "Helvetica",
+  "Times New Roman",
+  "Georgia",
+  "Verdana",
+  "Courier New",
+  "Impact",
+];
+
+const DEFAULT_PLACEHOLDER_TEXT = "Text";
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for adding and styling text on the canvas
+ *
+ * @example
+ * ```tsx
+ * const text = useText(canvasRef, imageRef, {
+ *   defaultColor: '#000000',
+ *   onTextAdd: (textObj) => {
+ *     saveState();
+ *   }
+ * });
+ *
+ * // Add text
+ * text.addText("Hello World");
+ *
+ * // Style selected text
+ * text.setFontSize(32);
+ * text.setFontFamily("Georgia");
+ * ```
+ */
+export function useText(
+  canvasRef: React.MutableRefObject<fabric.Canvas | null>,
+  imageRef: React.MutableRefObject<fabric.Image | null>,
+  options: UseTextOptions = {}
+): UseTextReturn {
+  const {
+    defaultColor = "#000000",
+    defaultFontSize = 24,
+    defaultFontFamily = "Arial",
+    onTextAdd,
+    onTextEditEnd,
+  } = options;
+
+  /**
+   * Calculate text position (centered in viewport, clamped to image)
+   */
+  const calculateTextPosition = useCallback(
+    (
+      canvas: fabric.Canvas,
+      textWidth: number,
+      textHeight: number
+    ): { x: number; y: number } => {
+      const originalImage = imageRef.current;
+      const imgBounds = getImageBounds(originalImage);
+
+      const viewportCenter = getViewportCenter(canvas);
+      let x = viewportCenter.x;
+      let y = viewportCenter.y;
+
+      if (imgBounds) {
+        const halfWidth = textWidth / 2;
+        const halfHeight = textHeight / 2;
+
+        x = Math.max(
+          imgBounds.left + halfWidth + 10,
+          Math.min(x, imgBounds.left + imgBounds.width - halfWidth - 10)
+        );
+        y = Math.max(
+          imgBounds.top + halfHeight + 10,
+          Math.min(y, imgBounds.top + imgBounds.height - halfHeight - 10)
+        );
+      }
+
+      return { x, y };
+    },
+    [imageRef]
+  );
+
+  /**
+   * Add text object to canvas
+   */
+  const addText = useCallback(
+    (initialText: string = DEFAULT_PLACEHOLDER_TEXT) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const textObj = new fabric.IText(initialText, {
+        fill: defaultColor,
+        fontSize: defaultFontSize,
+        fontFamily: defaultFontFamily,
+        originX: "center",
+        originY: "center",
+        editable: true,
+        selectable: true,
+        evented: true,
+        hasControls: true,
+        hasBorders: true,
+        cornerColor: defaultColor,
+        cornerSize: 10,
+        transparentCorners: false,
+        objectCaching: false,
+      });
+
+      // Calculate estimated dimensions for positioning
+      const estimatedWidth = textObj.width || 100;
+      const estimatedHeight = textObj.height || defaultFontSize;
+
+      const position = calculateTextPosition(
+        canvas,
+        estimatedWidth,
+        estimatedHeight
+      );
+      textObj.set({
+        left: position.x,
+        top: position.y,
+      });
+
+      // Add custom properties
+      const customText = textObj as EditorFabricObject;
+      customText.isText = true;
+      customText.isShape = true;
+      customText.shapeType = "text";
+      customText.id = `text-${Date.now()}`;
+
+      // Add event listener for editing end
+      textObj.on("editing:exited", () => {
+        onTextEditEnd?.(textObj);
+      });
+
+      canvas.add(textObj);
+      canvas.setActiveObject(textObj);
+      canvas.renderAll();
+
+      // Enter editing mode immediately
+      textObj.enterEditing();
+      textObj.selectAll();
+
+      onTextAdd?.(textObj);
+    },
+    [
+      canvasRef,
+      calculateTextPosition,
+      defaultColor,
+      defaultFontSize,
+      defaultFontFamily,
+      onTextAdd,
+      onTextEditEnd,
+    ]
+  );
+
+  /**
+   * Set font size of selected text
+   */
+  const setFontSize = useCallback(
+    (size: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const activeObject = canvas.getActiveObject();
+      if (activeObject && activeObject.type === "i-text") {
+        (activeObject as fabric.IText).set({ fontSize: size });
+        canvas.renderAll();
+      }
+    },
+    [canvasRef]
+  );
+
+  /**
+   * Set font family of selected text
+   */
+  const setFontFamily = useCallback(
+    (family: string) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const activeObject = canvas.getActiveObject();
+      if (activeObject && activeObject.type === "i-text") {
+        (activeObject as fabric.IText).set({ fontFamily: family });
+        canvas.renderAll();
+      }
+    },
+    [canvasRef]
+  );
+
+  /**
+   * Set text color of selected text
+   */
+  const setTextColor = useCallback(
+    (color: string) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const activeObject = canvas.getActiveObject();
+      if (activeObject && activeObject.type === "i-text") {
+        (activeObject as fabric.IText).set({ fill: color });
+        canvas.renderAll();
+      }
+    },
+    [canvasRef]
+  );
+
+  /**
+   * Set font weight (bold)
+   */
+  const setFontWeight = useCallback(
+    (weight: "normal" | "bold") => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const activeObject = canvas.getActiveObject();
+      if (activeObject && activeObject.type === "i-text") {
+        (activeObject as fabric.IText).set({ fontWeight: weight });
+        canvas.renderAll();
+      }
+    },
+    [canvasRef]
+  );
+
+  /**
+   * Set font style (italic)
+   */
+  const setFontStyle = useCallback(
+    (style: "normal" | "italic") => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const activeObject = canvas.getActiveObject();
+      if (activeObject && activeObject.type === "i-text") {
+        (activeObject as fabric.IText).set({ fontStyle: style });
+        canvas.renderAll();
+      }
+    },
+    [canvasRef]
+  );
+
+  return {
+    addText,
+    setFontSize,
+    setFontFamily,
+    setTextColor,
+    setFontWeight,
+    setFontStyle,
+    fontFamilies: DEFAULT_FONT_FAMILIES,
+  };
+}
+
+export default useText;

--- a/src/core/hooks/useText.ts
+++ b/src/core/hooks/useText.ts
@@ -118,7 +118,6 @@ export function useText(
       if (!canvas) return;
 
       const textObj = new fabric.IText(initialText, {
-        fill: defaultColor,
         fontSize: defaultFontSize,
         fontFamily: defaultFontFamily,
         originX: "center",
@@ -128,7 +127,6 @@ export function useText(
         evented: true,
         hasControls: true,
         hasBorders: true,
-        cornerColor: defaultColor,
         cornerSize: 10,
         transparentCorners: false,
         objectCaching: false,
@@ -143,7 +141,13 @@ export function useText(
         estimatedWidth,
         estimatedHeight
       );
+
+      // Set fill and position explicitly after construction
+      // This ensures the color is applied correctly (Fabric.js IText quirk)
       textObj.set({
+        fill: defaultColor,
+        cornerColor: defaultColor,
+        borderColor: defaultColor,
         left: position.x,
         top: position.y,
       });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -38,6 +38,7 @@ export {
   useCrop,
   useDrawing,
   useShapes,
+  useText,
   useSelection,
   useZoom,
   useExport,
@@ -90,6 +91,7 @@ export type {
   EditorFabricCanvas,
   EditorFabricRect,
   EditorFabricPath,
+  EditorFabricIText,
   // Core types
   ShapeType,
   EditorMode,
@@ -111,6 +113,7 @@ export type {
   UseCropReturn,
   UseDrawingReturn,
   UseShapesReturn,
+  UseTextReturn,
   UseSelectionReturn,
   UseZoomReturn,
   UsePanReturn,

--- a/src/core/types/fabric.types.ts
+++ b/src/core/types/fabric.types.ts
@@ -7,7 +7,7 @@ import type { fabric } from "fabric";
 /**
  * Shape types supported by the editor
  */
-export type ShapeType = "rectangle" | "circle";
+export type ShapeType = "rectangle" | "circle" | "text";
 
 /**
  * Editor mode states
@@ -23,7 +23,8 @@ export type EditorTool =
   | "crop"
   | "blur"
   | "rectangle"
-  | "circle";
+  | "circle"
+  | "text";
 
 /**
  * Extended Fabric.js Object with custom properties for the image editor
@@ -33,6 +34,17 @@ export interface EditorFabricObject extends fabric.Object {
   isDrawing?: boolean;
   isBlurPatch?: boolean;
   blurRectId?: string;
+  isShape?: boolean;
+  shapeType?: ShapeType;
+  isText?: boolean;
+}
+
+/**
+ * Extended Fabric.js IText for text objects
+ */
+export interface EditorFabricIText extends fabric.IText {
+  id?: string;
+  isText?: boolean;
   isShape?: boolean;
   shapeType?: ShapeType;
 }

--- a/src/core/types/hooks.types.ts
+++ b/src/core/types/hooks.types.ts
@@ -119,6 +119,26 @@ export interface UseShapesReturn {
 }
 
 /**
+ * Return type for useText hook
+ */
+export interface UseTextReturn {
+  /** Add a text object to canvas */
+  addText: (initialText?: string) => void;
+  /** Set font size of selected text */
+  setFontSize: (size: number) => void;
+  /** Set font family of selected text */
+  setFontFamily: (family: string) => void;
+  /** Set text color of selected text */
+  setTextColor: (color: string) => void;
+  /** Set font weight (bold) */
+  setFontWeight: (weight: "normal" | "bold") => void;
+  /** Set font style (italic) */
+  setFontStyle: (style: "normal" | "italic") => void;
+  /** Available font families */
+  fontFamilies: string[];
+}
+
+/**
  * Return type for useSelection hook
  */
 export interface UseSelectionReturn {
@@ -248,6 +268,23 @@ export interface UseImageEditorReturn {
     addCircle: () => void;
     /** Add shape by type */
     add: (type: ShapeType) => void;
+  };
+
+  text: {
+    /** Add text object */
+    add: (initialText?: string) => void;
+    /** Set font size */
+    setFontSize: (size: number) => void;
+    /** Set font family */
+    setFontFamily: (family: string) => void;
+    /** Set text color */
+    setColor: (color: string) => void;
+    /** Set font weight */
+    setFontWeight: (weight: "normal" | "bold") => void;
+    /** Set font style */
+    setFontStyle: (style: "normal" | "italic") => void;
+    /** Available font families */
+    fontFamilies: string[];
   };
 
   selection: {

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -15,6 +15,7 @@ export type {
   EditorFabricCanvas,
   EditorFabricRect,
   EditorFabricPath,
+  EditorFabricIText,
   FabricSelectionEvent,
   FabricPathCreatedEvent,
 } from "./fabric.types";
@@ -33,6 +34,7 @@ export type {
   UseCropReturn,
   UseDrawingReturn,
   UseShapesReturn,
+  UseTextReturn,
   UseSelectionReturn,
   UseZoomReturn,
   UsePanReturn,


### PR DESCRIPTION
## Summary
- Added text tool with support for adding and styling text on images
- Support for font size, font family, font weight, font style, and color customization
- Text objects integrate with existing color picker and selection system
- Fixed color application to text fill and border when text is selected

## Changes
- New `useText` hook for text manipulation
- Updated `useSelection` to properly handle text color changes (fill vs stroke)
- Added text types and interfaces to type system
- Integrated text tool into main `useImageEditor` hook