### PR TITLE
fix: npm publish issues (husky + types path)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ozdemircibaris/react-image-editor",
   "private": false,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Headless React image editor with blur, crop, shapes, drawing, and undo/redo. Use the hooks for custom UI or the styled components for quick integration.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "Headless React image editor with blur, crop, shapes, drawing, and undo/redo. Use the hooks for custom UI or the styled components for quick integration.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/components/imageEditor/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/components/imageEditor/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
## Summary
- Make husky optional in prepare script for npm publish (devDeps not available during publish)
- Fix TypeScript types path pointing to correct location (`dist/components/imageEditor/index.d.ts`)

## Changes
- `"prepare": "husky"` → `"prepare": "husky || true"`
- `"types": "dist/index.d.ts"` → `"types": "dist/components/imageEditor/index.d.ts"`